### PR TITLE
feat: detect nmap for default scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,6 +1347,7 @@ dependencies = [
  "text_placeholder",
  "toml",
  "wait-timeout",
+ "which",
 ]
 
 [[package]]
@@ -1755,6 +1765,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9cad3279ade7346b96e38731a641d7343dd6a53d55083dd54eadfa5a1b38c6b"
+dependencies = [
+ "either",
+ "home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "widestring"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +1970,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ anyhow = "1.0.40"
 subprocess = "0.2.6"
 text_placeholder = { version = "0.5", features = ["struct_context"] }
 once_cell = "1.20.2"
+which = "7.0.0"
 
 [dev-dependencies]
 parameterized = "2.0.0"


### PR DESCRIPTION
If using a the equivalent of `--scripts default`, we're currently defaulting to `nmap`. However, as per #691, if it's not there, RustScan errors after completing the port-scan.

Making use of [`which`](https://github.com/harryfei/which-rs) to verify that an `nmap` binary can be found; this looks like:

```sh
❯ ./target/debug/rustscan --addresses 127.0.0.1 --scripts default
[!] Initiating scripts failed!
nmap: command not found. See <https://nmap.org/download>
```

1. is this something we actually want?
   - alternatively, we could log and disable the scripting engine. 
3. if so, is the above adequate messaging?
4. although I can verify the behaviour, how can we wrap this in a unit test?

closes #691