### PR TITLE
Support ranges in port cli argument

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,7 @@
 //!
 //! fn main() {
 //!     let addrs = vec!["127.0.0.1".parse::<IpAddr>().unwrap()];
-//!     let range = PortRange {
-//!         start: 1,
-//!         end: 1_000,
-//!     };
-//!     let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random); // can be serial, random or manual https://github.com/RustScan/RustScan/blob/master/src/port_strategy/mod.rs
+//!     let strategy = PortStrategy::pick(Some((1..=1_000).collect()), ScanOrder::Random); // can be serial, random or manual https://github.com/RustScan/RustScan/blob/master/src/port_strategy/mod.rs
 //!     let scanner = Scanner::new(
 //!         &addrs, // the addresses to scan
 //!         10, // batch_size is how many ports at a time should be scanned

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ fn main() {
         Duration::from_millis(opts.timeout.into()),
         opts.tries,
         opts.greppable,
-        PortStrategy::pick(&opts.range, opts.ports, opts.scan_order),
+        PortStrategy::pick(opts.ports, opts.scan_order),
         opts.accessible,
         opts.exclude_ports.unwrap_or_default(),
         opts.udp,

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -318,11 +318,7 @@ mod tests {
     fn scanner_runs() {
         // Makes sure the program still runs and doesn't panic
         let addrs = vec!["127.0.0.1".parse::<IpAddr>().unwrap()];
-        let range = PortRange {
-            start: 1,
-            end: 1_000,
-        };
-        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(Some((0..=1000).collect()), ScanOrder::Random);
         let scanner = Scanner::new(
             &addrs,
             10,
@@ -342,11 +338,7 @@ mod tests {
     fn ipv6_scanner_runs() {
         // Makes sure the program still runs and doesn't panic
         let addrs = vec!["::1".parse::<IpAddr>().unwrap()];
-        let range = PortRange {
-            start: 1,
-            end: 1_000,
-        };
-        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(Some((0..=1000).collect()), ScanOrder::Random);
         let scanner = Scanner::new(
             &addrs,
             10,
@@ -365,11 +357,7 @@ mod tests {
     #[test]
     fn quad_zero_scanner_runs() {
         let addrs = vec!["0.0.0.0".parse::<IpAddr>().unwrap()];
-        let range = PortRange {
-            start: 1,
-            end: 1_000,
-        };
-        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(Some((0..=1000).collect()), ScanOrder::Random);
         let scanner = Scanner::new(
             &addrs,
             10,
@@ -387,11 +375,7 @@ mod tests {
     #[test]
     fn google_dns_runs() {
         let addrs = vec!["8.8.8.8".parse::<IpAddr>().unwrap()];
-        let range = PortRange {
-            start: 400,
-            end: 445,
-        };
-        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(Some((400..=445).collect()), ScanOrder::Random);
         let scanner = Scanner::new(
             &addrs,
             10,
@@ -412,11 +396,7 @@ mod tests {
         let addrs = vec!["8.8.8.8".parse::<IpAddr>().unwrap()];
 
         // mac should have this automatically scaled down
-        let range = PortRange {
-            start: 400,
-            end: 600,
-        };
-        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(Some((400..=600).collect()), ScanOrder::Random);
         let scanner = Scanner::new(
             &addrs,
             10,
@@ -436,11 +416,7 @@ mod tests {
     fn udp_scan_runs() {
         // Makes sure the program still runs and doesn't panic
         let addrs = vec!["127.0.0.1".parse::<IpAddr>().unwrap()];
-        let range = PortRange {
-            start: 1,
-            end: 1_000,
-        };
-        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(Some((0..=1000).collect()), ScanOrder::Random);
         let scanner = Scanner::new(
             &addrs,
             10,
@@ -460,11 +436,7 @@ mod tests {
     fn udp_ipv6_runs() {
         // Makes sure the program still runs and doesn't panic
         let addrs = vec!["::1".parse::<IpAddr>().unwrap()];
-        let range = PortRange {
-            start: 1,
-            end: 1_000,
-        };
-        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(Some((0..=1000).collect()), ScanOrder::Random);
         let scanner = Scanner::new(
             &addrs,
             10,
@@ -483,11 +455,7 @@ mod tests {
     #[test]
     fn udp_quad_zero_scanner_runs() {
         let addrs = vec!["0.0.0.0".parse::<IpAddr>().unwrap()];
-        let range = PortRange {
-            start: 1,
-            end: 1_000,
-        };
-        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(Some((0..=1000).collect()), ScanOrder::Random);
         let scanner = Scanner::new(
             &addrs,
             10,
@@ -505,11 +473,7 @@ mod tests {
     #[test]
     fn udp_google_dns_runs() {
         let addrs = vec!["8.8.8.8".parse::<IpAddr>().unwrap()];
-        let range = PortRange {
-            start: 100,
-            end: 150,
-        };
-        let strategy = PortStrategy::pick(&Some(range), None, ScanOrder::Random);
+        let strategy = PortStrategy::pick(Some((100..=150).collect()), ScanOrder::Random);
         let scanner = Scanner::new(
             &addrs,
             10,


### PR DESCRIPTION
Hey!
I was working on port scanner wrapper over the rustscan and encountered the problem - I can't supply all 65535 ports in specific order to rustscan, because bash can't handle such long arguments. I started researching rustscan code and found, that we can't set multiple ranges of ports in cli-args. I tried to fix it and got all tests passed after my manipulations, but I understand, that my changes can break interface of library for projects.
What do you think about implementing universal flag "--ports"? I mean "--ports 80,443,8000-8080,9999" for example
