### PR TITLE
README.md: fix arch install, install guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ MacOS:
 Arch:
 
 ```
-  yay rustscan
+  pacman -S rustscan
 ```
 
 # ✨ Features
@@ -55,7 +55,7 @@ Arch:
 
 |         <!--Installation Guide-->          |          <!--Documentation-->          |       <!--Discord-->        |
 | :----------------------------------------: | :------------------------------------: | :-------------------------: |
-| :book: [Installation Guide][links-table-1] | :books: [Documentation][links-table-2] | :parrot: [Discord][discord] |
+| :book: [Installation Guide][toc-install] | :books: [Documentation][links-table-2] | :parrot: [Discord][discord] |
 
 ## 🙋 Table of Contents
 


### PR DESCRIPTION
The example installation for Arch Linux previously showed installation via yay, which is an unofficial package manager only required if installing from the AUR. Since rustscan is in the official extra package repository, change the instructions to use pacman.

While here, also fix link to full install guide.